### PR TITLE
Add ability to embed sheets and render objects from multiple app ids

### DIFF
--- a/qlik-saas/trunk/auth.php
+++ b/qlik-saas/trunk/auth.php
@@ -17,15 +17,15 @@
 	
 			$payload = [
 					'iss'  						=> $settings['host'],									// Issuer
-					"aud"							=> 'qlik.api/login/jwt-session',
+					"aud"						=> 'qlik.api/login/jwt-session',
 					'iat'  						=> $issuedAt->getTimestamp(),					// Issued at: time when the token was generated
 					'nbf'  						=> $issuedAt->getTimestamp(),					// This is the time that the token can actually be used
-					'exp'							=> $expire,
-					'sub'							=> 'anon-view-sub',
+					'exp'						=> $expire,
+					'sub'						=> 'anon-view-sub',
 					'subType'					=> 'user',
 					'name'						=> 'Anon Viewer',
 					'email'						=> 'anon-viewer@qlik.com',
-					'email_verified'	=> true,
+					'email_verified'			=> true,
 					'groups'					=> ['anon-view'],
 			];
 			

--- a/qlik-saas/trunk/js/iframe-sheet.js
+++ b/qlik-saas/trunk/js/iframe-sheet.js
@@ -36,7 +36,7 @@ const init = async () => {
       const theAppId = settings.appID !== '' ? settings.appID : sheets[i].getAttribute('app-id');
       const width = sheets[i].getAttribute('width');
       const height = sheets[i].getAttribute('height');
-      iframe.src = `https://${settings.host}/single?appid=${theAppId}&sheet=${sheetID}&opt=currsel&qlik-web-integration-id=${settings.webIntegrationID}&identity=${qs_identity}`;
+      iframe.src = `https://${settings.host}/single/?appid=${theAppId}&sheet=${sheetID}&opt=currsel&qlik-web-integration-id=${settings.webIntegrationID}&identity=${qs_identity}`;
       iframe.height = height;
       iframe.width = width;
       sheets[i].appendChild(iframe);

--- a/qlik-saas/trunk/js/iframe-sheet.js
+++ b/qlik-saas/trunk/js/iframe-sheet.js
@@ -28,7 +28,6 @@ const init = async () => {
     if(!qs_csrf) {
       await checkStatus();
     }
-    const identity = `${Date.now().toString()}_ANON`;
     var sheets = document.querySelectorAll('[qlik-saas-sheet-id]');
     // Loop over all selected elements
     for (i = 0; i < sheets.length; ++i) {
@@ -37,7 +36,7 @@ const init = async () => {
       const theAppId = settings.appID !== '' ? settings.appID : sheets[i].getAttribute('app-id');
       const width = sheets[i].getAttribute('width');
       const height = sheets[i].getAttribute('height');
-      iframe.src = `https://${settings.host}/single?appid=${theAppId}&sheet=${sheetID}&opt=currsel&qlik-web-integration-id=${settings.webIntegrationID}&identity=${identity}`;
+      iframe.src = `https://${settings.host}/single?appid=${theAppId}&sheet=${sheetID}&opt=currsel&qlik-web-integration-id=${settings.webIntegrationID}&identity=${qs_identity}`;
       iframe.height = height;
       iframe.width = width;
       sheets[i].appendChild(iframe);

--- a/qlik-saas/trunk/js/iframe-sheet.js
+++ b/qlik-saas/trunk/js/iframe-sheet.js
@@ -20,11 +20,14 @@ const connect = async () => {
     },
     rejectUnauthorized: false,
   });
+  qs_csrf = true;
 };
 
 const init = async () => {
   try {
-    await checkStatus();
+    if(!qs_csrf) {
+      await checkStatus();
+    }
     const identity = `${Date.now().toString()}_ANON`;
     var sheets = document.querySelectorAll('[qlik-saas-sheet-id]');
     // Loop over all selected elements

--- a/qlik-saas/trunk/js/iframe-sheet.js
+++ b/qlik-saas/trunk/js/iframe-sheet.js
@@ -31,9 +31,10 @@ const init = async () => {
     for (i = 0; i < sheets.length; ++i) {
       const iframe = document.createElement('iframe');
       const sheetID = sheets[i].getAttribute('qlik-saas-sheet-id');
+      const theAppId = settings.appID !== '' ? settings.appID : sheets[i].getAttribute('app-id');
       const width = sheets[i].getAttribute('width');
       const height = sheets[i].getAttribute('height');
-      iframe.src = `https://${settings.host}/single?appid=${settings.appID}&sheet=${sheetID}&opt=currsel&qlik-web-integration-id=${settings.webIntegrationID}&identity=${identity}`;
+      iframe.src = `https://${settings.host}/single?appid=${theAppId}&sheet=${sheetID}&opt=currsel&qlik-web-integration-id=${settings.webIntegrationID}&identity=${identity}`;
       iframe.height = height;
       iframe.width = width;
       sheets[i].appendChild(iframe);

--- a/qlik-saas/trunk/js/nebula.js
+++ b/qlik-saas/trunk/js/nebula.js
@@ -1,3 +1,4 @@
+console.log('new no anoonnnnn');
 const login = async () => {
     await fetch(`https://${settings.host}/login/jwt-session?qlik-web-integration-id=${settings.webIntegrationID}`, {
       method: 'POST',
@@ -36,7 +37,7 @@ const initNebula = async () => {
       const theAppId = settings.appID !== '' ? settings.appID : objects[i].getAttribute('app-id');
 
       //neb
-      const url = `wss://${settings.host}/app/${theAppId}?qlik-web-integration-id=${settings.webIntegrationID}&qlik-csrf-token=${csrfToken}`;
+      const url = `wss://${settings.host}/app/${theAppId}/identity/${qs_identity}?qlik-web-integration-id=${settings.webIntegrationID}&qlik-csrf-token=${csrfToken}`;
       const schema = await ( await fetch("https://unpkg.com/enigma.js/schemas/3.2.json") ).json();
       const session = window.enigma.create({ schema, url });
       const app = await (await session.open()).openDoc(theAppId);

--- a/qlik-saas/trunk/js/nebula.js
+++ b/qlik-saas/trunk/js/nebula.js
@@ -1,18 +1,18 @@
-
 const login = async () => {
-  await fetch(`https://${settings.host}/login/jwt-session?qlik-web-integration-id=${settings.webIntegrationID}`, {
-    method: 'POST',
-    credentials: 'include',
-    mode: 'cors',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${settings.token}`,
-      'Qlik-Web-Integration-ID':settings.webIntegrationID,
-    },
-    rejectUnauthorized: false,
-  });
-};
-
+    await fetch(`https://${settings.host}/login/jwt-session?qlik-web-integration-id=${settings.webIntegrationID}`, {
+      method: 'POST',
+      credentials: 'include',
+      mode: 'cors',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${settings.token}`,
+        'Qlik-Web-Integration-ID':settings.webIntegrationID,
+      },
+      rejectUnauthorized: false,
+    });
+    qs_csrf = true;
+  };
+  
 const getCsrfTokenInfo = async () => {
   const response = await fetch(`https://${settings.host}/api/v1/csrf-token`, {
     credentials: "include",
@@ -20,89 +20,98 @@ const getCsrfTokenInfo = async () => {
   });
   return response.headers.get("qlik-csrf-token");
 }
-
-const init = async () => {
+  
+const initNebula = async () => {
   try {
-    await login();
+    if(!qs_csrf) {
+      await login();
+    }
     const csrfToken = await getCsrfTokenInfo();
-    
-    const url = `wss://${settings.host}/app/${settings.appID}?qlik-web-integration-id=${settings.webIntegrationID}&qlik-csrf-token=${csrfToken}`;
-    const schema = await ( await fetch("https://unpkg.com/enigma.js/schemas/3.2.json") ).json();
-    const session = window.enigma.create({ schema, url });
-    const app = await (await session.open()).openDoc(settings.appID);
 
-    const nuked = await window.stardust.embed(app, {
-      types: [
-        {
-          name: "kpi",
-          load: () => Promise.resolve(window["sn-kpi"])
-        },
-        {
-          name: "scatterplot",
-          load: () => Promise.resolve(window["sn-scatter-plot"])
-        },
-        {
-          name: "distributionplot",
-          load: () => Promise.resolve(window["sn-distributionplot"])
-        },
-        {
-          name: "barchart",
-          load: () => Promise.resolve(window["sn-bar-chart"])
-        },
-        {
-          name: "linechart",
-          load: () => Promise.resolve(window["sn-line-chart"])
-        },
-        {
-          name: "table",
-          load: () => Promise.resolve(window["sn-table"])
-        },
-        {
-          name: "piechart",
-          load: () => Promise.resolve(window["sn-pie-chart"])
-        },
-        {
-          name: "sankeychart",
-          load: () => Promise.resolve(window["sn-sankey-chart"])
-        },
-        {
-          name: "funnelchart",
-          load: () => Promise.resolve(window["sn-funnel-chart"])
-        },
-        {
-          name: "mekkochart",
-          load: () => Promise.resolve(window["sn-mekko-chart"])
-        },
-        {
-          name: "gridchart",
-          load: () => Promise.resolve(window["sn-grid-chart"])
-        },
-        {
-          name: "bulletchart",
-          load: () => Promise.resolve(window["sn-bullet-chart"])
-        },
-        {
-          name: "combochart",
-          load: () => Promise.resolve(window["sn-combo-chart"])
-        },
-      ]
-    });
-    
-    // render viz
-    const kpis = document.querySelectorAll('[qlik-saas-object-id]');
-    for (i = 0; i < kpis.length; ++i) {
-      const id = kpis[i].getAttribute('qlik-saas-object-id')
+    var objects = document.querySelectorAll('[qlik-saas-object-id]');
+
+    // Loop through all selected objects
+    for (i = 0; i < objects.length; ++i) {
+      const id = objects[i].getAttribute('qlik-saas-object-id')
+      const theAppId = settings.appID !== '' ? settings.appID : objects[i].getAttribute('app-id');
+
+      //neb
+      const url = `wss://${settings.host}/app/${theAppId}?qlik-web-integration-id=${settings.webIntegrationID}&qlik-csrf-token=${csrfToken}`;
+      const schema = await ( await fetch("https://unpkg.com/enigma.js/schemas/3.2.json") ).json();
+      const session = window.enigma.create({ schema, url });
+      const app = await (await session.open()).openDoc(theAppId);
+      
+      const nuked = await window.stardust.embed(app, {
+        types: [
+          {
+            name: "kpi",
+            load: () => Promise.resolve(window["sn-kpi"])
+          },
+          {
+            name: "scatterplot",
+            load: () => Promise.resolve(window["sn-scatter-plot"])
+          },
+          {
+            name: "distributionplot",
+            load: () => Promise.resolve(window["sn-distributionplot"])
+          },
+          {
+            name: "barchart",
+            load: () => Promise.resolve(window["sn-bar-chart"])
+          },
+          {
+            name: "linechart",
+            load: () => Promise.resolve(window["sn-line-chart"])
+          },
+          {
+            name: "table",
+            load: () => Promise.resolve(window["sn-table"])
+          },
+          {
+            name: "piechart",
+            load: () => Promise.resolve(window["sn-pie-chart"])
+          },
+          {
+            name: "sankeychart",
+            load: () => Promise.resolve(window["sn-sankey-chart"])
+          },
+          {
+            name: "funnelchart",
+            load: () => Promise.resolve(window["sn-funnel-chart"])
+          },
+          {
+            name: "mekkochart",
+            load: () => Promise.resolve(window["sn-mekko-chart"])
+          },
+          {
+            name: "gridchart",
+            load: () => Promise.resolve(window["sn-grid-chart"])
+          },
+          {
+            name: "bulletchart",
+            load: () => Promise.resolve(window["sn-bullet-chart"])
+          },
+          {
+            name: "combochart",
+            load: () => Promise.resolve(window["sn-combo-chart"])
+          },
+        ]
+      });
+
+      // render
       if (id === 'selections') {
-        (await nuked.selections()).mount(kpis[i])
+        (await nuked.selections()).mount(objects[i])
       } else 
       await nuked.render({
-        element: kpis[i],
+        element: objects[i],
         id,
       });
+
     }
+
   } catch (error) {
     console.error(error);
   }
 };
 
-init();
+initNebula();

--- a/qlik-saas/trunk/js/nebula.js
+++ b/qlik-saas/trunk/js/nebula.js
@@ -1,4 +1,3 @@
-console.log('new no anoonnnnn');
 const login = async () => {
     await fetch(`https://${settings.host}/login/jwt-session?qlik-web-integration-id=${settings.webIntegrationID}`, {
       method: 'POST',
@@ -12,7 +11,7 @@ const login = async () => {
       rejectUnauthorized: false,
     });
     qs_csrf = true;
-  };
+};
   
 const getCsrfTokenInfo = async () => {
   const response = await fetch(`https://${settings.host}/api/v1/csrf-token`, {

--- a/qlik-saas/trunk/qlik-saas.php
+++ b/qlik-saas/trunk/qlik-saas.php
@@ -101,6 +101,7 @@
 	?>
 		<script type="text/javascript">
 			var qs_csrf = false;
+			var qs_identity = `${Date.now().toString()}_ANON`;
 		</script>
 	<?php
 	}

--- a/qlik-saas/trunk/qlik-saas.php
+++ b/qlik-saas/trunk/qlik-saas.php
@@ -15,8 +15,8 @@
 
 	defined('ABSPATH') or die("No script kiddies please!"); //Block direct access to this php file
 
-  define( 'QLIK_SAAS_PLUGIN_VERSION', '1.0.7' );
-  define( 'QLIK_SAAS_PLUGIN_MINIMUM_WP_VERSION', '5.1' );
+  	define( 'QLIK_SAAS_PLUGIN_VERSION', '1.0.7' );
+    define( 'QLIK_SAAS_PLUGIN_MINIMUM_WP_VERSION', '5.1' );
 	define( 'QLIK_SAAS_PLUGIN_PLUGIN_DIR', plugin_dir_url( __FILE__ ) );
 	
 	add_action('admin_menu', 'qlik_saas_plugin_menu');
@@ -120,12 +120,12 @@
 		$settings = array(	
 			'version'						=> QLIK_SAAS_PLUGIN_VERSION,
 			'host'							=> esc_attr( get_option('qs_host') ),
-			'webIntegrationID'	=> esc_attr( get_option('qs_webintegrationid') ),
+			'webIntegrationID'				=> esc_attr( get_option('qs_webintegrationid') ),
 			'appID'							=> esc_attr( get_option('qs_appid') ),	
 		);
 		$tokenSettings = array(
 			'host'							=> esc_attr( get_option('qs_host') ),
-			'privateKey'				=> esc_attr( get_option('qs_privateKey') ),		
+			'privateKey'					=> esc_attr( get_option('qs_privateKey') ),		
 			'keyID'							=> esc_attr( get_option('qs_keyid') ),
 		);
 		$settings['token'] = qlik_saas_jwt($tokenSettings);
@@ -142,17 +142,17 @@
 		$settings = array(	
 			'version'						=> QLIK_SAAS_PLUGIN_VERSION,
 			'host'							=> esc_attr( get_option('qs_host') ),
-			'webIntegrationID'	=> esc_attr( get_option('qs_webintegrationid') ),
-			'appID'							=> esc_attr( get_option('qs_appid') ),	
+			'webIntegrationID'				=> esc_attr( get_option('qs_webintegrationid') ),
+			'appID'							=> !empty(get_option('qs_appid')) ? esc_attr( get_option('qs_appid') ) : '',
 		);
 		$tokenSettings = array(
 			'host'							=> esc_attr( get_option('qs_host') ),
-			'privateKey'				=> esc_attr( get_option('qs_privateKey') ),		
+			'privateKey'					=> esc_attr( get_option('qs_privateKey') ),		
 			'keyID'							=> esc_attr( get_option('qs_keyid') ),
 		);
 		$settings['token'] = qlik_saas_jwt($tokenSettings);
 		wp_localize_script( 'qlik-saas-iframe-sheet-js', 'settings', $settings );
-		return "<div qlik-saas-sheet-id=\"{$atts['id']}\" width=\"100%\" height=\"{$atts['height']}\" style=\"display: block;\"></div>";
+		return "<div qlik-saas-sheet-id=\"{$atts['id']}\" app-id=\"{$atts['appid']}\" width=\"100%\" height=\"{$atts['height']}\" style=\"display: block;\"></div>";
 	}
 	add_shortcode( 'qlik-saas-single-sheet', 'qlik_saas_single_sheet_func' );
 

--- a/qlik-saas/trunk/qlik-saas.php
+++ b/qlik-saas/trunk/qlik-saas.php
@@ -81,7 +81,7 @@
 		wp_register_script( 'qlik-saas-iframe-sheet-js', QLIK_SAAS_PLUGIN_PLUGIN_DIR . 'js/iframe-sheet.js', QLIK_SAAS_PLUGIN_VERSION, $in_footer = true );
 		wp_register_script( 'qlik-saas-nebula', QLIK_SAAS_PLUGIN_PLUGIN_DIR . 'js/nebula.js', QLIK_SAAS_PLUGIN_VERSION, $in_footer = true );
 		wp_register_script( 'qlik-saas-enigma', 'https://unpkg.com/enigma.js@2.7.2/enigma.min.js', null, null, $in_footer = false );
-		wp_register_script( 'qlik-saas-stardust', 'https://unpkg.com/@nebula.js/stardust@1.1.1', null, null, $in_footer = false );
+		wp_register_script( 'qlik-saas-stardust', 'https://unpkg.com/@nebula.js/stardust', null, null, $in_footer = false );
 		wp_register_script( 'qlik-saas-snBarchart', 'https://unpkg.com/@nebula.js/sn-bar-chart', null, null, $in_footer = false );
 		wp_register_script( 'qlik-saas-snLinechart', 'https://unpkg.com/@nebula.js/sn-line-chart', null, null, $in_footer = false );
 		wp_register_script( 'qlik-saas-snSankeychart', 'https://unpkg.com/@nebula.js/sn-sankey-chart', null, null, $in_footer = false );
@@ -96,6 +96,15 @@
 		wp_register_script( 'qlik-saas-snDistributionplot', 'https://unpkg.com/@nebula.js/sn-distributionplot', null, null, $in_footer = false );
 		wp_register_script( 'qlik-saas-snPiechart', 'https://unpkg.com/@nebula.js/sn-pie-chart', null, null, $in_footer = false );
   }
+
+	function qs_register_csrf_variable(){ 
+	?>
+		<script type="text/javascript">
+			var qs_csrf = false;
+		</script>
+	<?php
+	}
+	add_action ( 'wp_head', 'qs_register_csrf_variable' );
 
 	// qlik-saas-object - Injects Nebula objects
 	// [qlik_saas_object id="CSxZqS" height="200"]
@@ -116,12 +125,11 @@
 		wp_enqueue_script( 'qlik-saas-snCombochart' );
 		wp_enqueue_script( 'qlik-saas-snDistributionplot' );
 		wp_enqueue_script( 'qlik-saas-snPiechart' );
-
 		$settings = array(	
 			'version'						=> QLIK_SAAS_PLUGIN_VERSION,
 			'host'							=> esc_attr( get_option('qs_host') ),
 			'webIntegrationID'				=> esc_attr( get_option('qs_webintegrationid') ),
-			'appID'							=> esc_attr( get_option('qs_appid') ),	
+			'appID'							=> !empty(get_option('qs_appid')) ? esc_attr( get_option('qs_appid') ) : '',
 		);
 		$tokenSettings = array(
 			'host'							=> esc_attr( get_option('qs_host') ),
@@ -130,7 +138,7 @@
 		);
 		$settings['token'] = qlik_saas_jwt($tokenSettings);
 		wp_localize_script( 'qlik-saas-nebula', 'settings', $settings );
-		return "<div qlik-saas-object-id=\"{$atts['id']}\" width=\"100%\" height=\"{$atts['height']}\" style=\"display: inline-block; position: relative; width: 100%; height: {$atts['height']}px;\"></div>";
+		return "<div qlik-saas-object-id=\"{$atts['id']}\" app-id=\"{$atts['appid']}\" width=\"100%\" height=\"{$atts['height']}\" style=\"display: inline-block; position: relative; width: 100%; height: {$atts['height']}px;\"></div>";
 	}
 	add_shortcode( 'qlik_saas_object', 'qlik_saas_object_func' );
 


### PR DESCRIPTION
- Changes: these changes came following a customer request to have the option to embed multiple sheets and/or objects from different apps.
- Bug: currently on the 1.0.7 version of the plugin on the Wordpress directory, the nebula.js file is missing.
- Added the same identity to nebula similar to iframe-sheet to allow for selection-aware embedded sheets and nebula objects.

![Qlik-Saas-Plugin-Files-New-Install](https://user-images.githubusercontent.com/8119026/146406574-4c187556-87b0-4800-ab20-a4c6c2b70849.PNG)

